### PR TITLE
fix(resources): crash on datetime.replace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
     },
     install_requires=[
         'Flask >=0.11.1',
+        'python-dateutil >=2.6.1',
     ],
 )

--- a/stripe_mock_server/resources.py
+++ b/stripe_mock_server/resources.py
@@ -20,6 +20,8 @@ import random
 import string
 import time
 
+from dateutil.relativedelta import relativedelta
+
 from .errors import UserError
 
 
@@ -854,15 +856,9 @@ class Subscription(StripeObject):
         elif plan.interval == 'week':
             current_period_end += timedelta(days=7)
         elif plan.interval == 'month':
-            current_period_end = current_period_start.replace(
-                month=(current_period_start.month % 12) + 1,
-                year=current_period_start.year +
-                int(current_period_start.month / 12))
+            current_period_end += relativedelta(months=1)
         elif plan.interval == 'year':
-            current_period_end = current_period_start.replace(
-                year=current_period_start.year + 1)
-        self.current_period_start = int(current_period_start.timestamp())
-        self.current_period_end = int(current_period_end.timestamp())
+            current_period_end += relativedelta(years=1)
 
         self.items = List('/v1/subscription_items?subscription=' + self.id)
         self.items._list.append(


### PR DESCRIPTION
`datetime.replace()` function doesn't manage days from us.

As consequence `(2017, 10, 31).replace(month=11)` will try to create
the date `(2017, 11, 31)` which doesn't exist.

In such case datetime lib crash with the following error:
```
ValueError: day is out of range for month
```

This commit replace the use of `datetime.replace()` to increment month,
by the use of `datetime + relativedelta()`.

`relativedelta()` function is part of `dateutils`, so I also add the
dependency in `setup.py`.