### PR TITLE
fix(server): Fix long time to start listening on some machines

### DIFF
--- a/stripe_mock_server/server.py
+++ b/stripe_mock_server/server.py
@@ -228,7 +228,7 @@ def start():
 
     PORT = args.port
 
-    app.run(host='0.0.0.0', port=args.port, debug=True)
+    app.run(host='::', port=args.port, debug=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On one of my laptops, stripe_mock_server took seconds before starting
listening on port 8420. It was because `app.run()` was very long. It
appears to be related to the fact that my system supports IPv6.

Let's listen on `::` (IPv6 version of "any interface"), which is
generally better than `0.0.0.0` because operating systems can map
IPv4 requests to this port, so both IPv4 and IPv6 requests succeed.
More info at https://stackoverflow.com/a/21689979.

And this solves the problem.

Average time between launch and first accepted HTTP request:
- before: 5.48 seconds
- after: 0.40 seconds