### PR TITLE
fix(resources): Treat metadata differently

### DIFF
--- a/stripe_mock_server/resources.py
+++ b/stripe_mock_server/resources.py
@@ -140,6 +140,14 @@ class StripeObject(object):
         for key, value in data.items():
             if key.startswith('_') or not hasattr(self, key):
                 raise UserError(400, 'Bad request')
+        # Treat metadata differently: do not delete absent fields
+        metadata = data.pop('metadata', None)
+        if metadata:
+            if type(metadata) is not dict:
+                raise UserError(400, 'Bad request')
+            self.metadata = self.metadata or {}
+            for key, value in metadata.items():
+                self.metadata[key] = value
         for key, value in data.items():
             setattr(self, key, value)
 


### PR DESCRIPTION
Some Stripe objects (Account, Charge, Customer, Refund, Subscription,
and Transfer) have metadata. When updating this metadata, absent values
should not be deleted.

This is a bit counter-intuitive, but this is the way the Python Stripe
library works.

For example, updating a Customer with `{"metadata": {"a": 1, "b": 2}}`
then, later, with `{"metadata": {"a": 3}}` should keep `b` unchanged.