### PR TITLE
Return CardError on special credit card numbers

### DIFF
--- a/stripe_mock_server/errors.py
+++ b/stripe_mock_server/errors.py
@@ -18,14 +18,11 @@ import flask
 
 
 class UserError(Exception):
-    def __init__(self, code, message=None):
+    def __init__(self, code, message=None, contents=None):
         Exception.__init__(self)
         self.code = code
-        self.body = {
-            'error': {
-                'type': 'invalid_request_error',
-            }
-        }
+        self.body = {'error': contents or {}}
+        self.body['error']['type'] = 'invalid_request_error'
         if message is not None:
             self.body['error']['message'] = message
 

--- a/stripe_mock_server/resources.py
+++ b/stripe_mock_server/resources.py
@@ -465,6 +465,9 @@ class Invoice(StripeObject):
 
         self._upcoming = upcoming
 
+        if not self._upcoming:
+            self.charge  # trigger creation of charge
+
     @property
     def subtotal(self):
         return sum([ii.amount for ii in self.lines._list])


### PR DESCRIPTION
#### fix(invoices): Really create a charge when paying

---

#### feat(charges): Return CardError on special credit card numbers

From Stripe documentation:
- 4000000000000002  Charge is declined with a card_declined code.
- 4000000000000127  Charge is declined with an incorrect_cvc code.
- 4000000000000069  Charge is declined with an expired_card code.
- 4000000000000119  Charge is declined with a processing_error code.
- 4242424242424241  Charge is declined with an incorrect_number code as
                    the card number fails the Luhn check.
